### PR TITLE
feat: handle CORS properly

### DIFF
--- a/lib/cli/src/Cardano/CLI.hs
+++ b/lib/cli/src/Cardano/CLI.hs
@@ -52,6 +52,7 @@ module Cardano.CLI
     , stateDirOption
     , syncToleranceOption
     , tlsOption
+    , permissiveCorsPolicyOption
     , poolMetadataSourceOption
     , tokenMetadataSourceOption
     , metadataOption
@@ -1212,6 +1213,12 @@ paymentOption = optionT $ mempty
     <> help
         ("address to send to and amount to send separated by @" <>
         ", e.g. '<amount>@<address>'")
+
+-- | [--permissive-cors-policy]
+permissiveCorsPolicyOption :: Parser Bool
+permissiveCorsPolicyOption = flag False True $ mempty
+    <> long "permissive-cors-policy"
+    <> help "enable permissive CORS policy"
 
 -- | [--address-pool-gap=INT], default: 20
 poolGapOption :: Parser AddressPoolGap

--- a/lib/shelley/cardano-wallet.cabal
+++ b/lib/shelley/cardano-wallet.cabal
@@ -96,6 +96,7 @@ library
     , unliftio-core
     , unordered-containers
     , vector
+    , wai-cors
     , warp
     , yaml
     , Win32-network

--- a/lib/shelley/exe/cardano-wallet.hs
+++ b/lib/shelley/exe/cardano-wallet.hs
@@ -54,6 +54,7 @@ import Cardano.CLI
     , loggingOptions
     , loggingSeverityOrOffReader
     , loggingTracers
+    , permissiveCorsPolicyOption
     , poolMetadataSourceOption
     , runCli
     , setupDirectory
@@ -178,7 +179,8 @@ beforeMainLoop tr = logInfo tr . MsgListenAddress
 
 -- | Arguments for the 'serve' command
 data ServeArgs = ServeArgs
-    { _hostPreference :: HostPreference
+    { _permissiveCorsPolicy :: Bool
+    , _hostPreference :: HostPreference
     , _mode :: Mode
     , _listen :: Listen
     , _tlsConfig :: Maybe TlsConfiguration
@@ -198,7 +200,8 @@ cmdServe = command "serve" $ info (helper <*> helper' <*> cmd) $
     helper' = helperTracing tracerDescriptions
 
     cmd = fmap exec $ ServeArgs
-        <$> hostPreferenceOption
+        <$> permissiveCorsPolicyOption
+        <*> hostPreferenceOption
         <*> modeOption
         <*> listenOption
         <*> optional tlsOption
@@ -212,6 +215,7 @@ cmdServe = command "serve" $ info (helper <*> helper' <*> cmd) $
 
     exec :: ServeArgs -> IO ()
     exec args@(ServeArgs
+      permissiveCorsPolicy
       host
       mode
       listen
@@ -245,6 +249,7 @@ cmdServe = command "serve" $ info (helper <*> helper' <*> cmd) $
                 blockchainSource
                 netParams
                 discriminant
+                permissiveCorsPolicy
                 tracers
                 sTolerance
                 databaseDir

--- a/lib/shelley/exe/local-cluster.hs
+++ b/lib/shelley/exe/local-cluster.hs
@@ -257,6 +257,7 @@ main = withLocalClusterSetup $ \dir clusterLogs walletLogs ->
                 (NodeSource socketPath vData)
                 gp
                 (SomeNetworkDiscriminant $ Proxy @'Mainnet)
+                False
                 tracers
                 (SyncTolerance 10)
                 (Just db)

--- a/lib/shelley/test/integration/shelley-integration-test.hs
+++ b/lib/shelley/test/integration/shelley-integration-test.hs
@@ -342,6 +342,7 @@ specWithServer testDir (tr, tracers) = aroundAll withContext
                 (NodeSource conn vData)
                 gp
                 (SomeNetworkDiscriminant $ Proxy @'Mainnet)
+                False
                 tracers
                 (SyncTolerance 10)
                 (Just db)


### PR DESCRIPTION
Handle CORS properly without NGINX.

Added a flag (`--permissive-cors-policy`) in the CLI to enable permissive CORS policy.